### PR TITLE
Add url_name to Player

### DIFF
--- a/app/load/main.py
+++ b/app/load/main.py
@@ -62,9 +62,7 @@ def load_players(player_dicts: list[dict], year: int):
         for player_dict in player_dicts:
             player_in = Player(
                 **player_dict,
-                attributes=PlayerAttributes(
-                    **player_dict, player_id=player_dict.get("PGID")
-                ),
+                attributes=PlayerAttributes(**player_dict),
                 teams=[],
             )
 

--- a/app/models.py
+++ b/app/models.py
@@ -27,7 +27,7 @@ class Player(SQLModel, table=True):
 
 class PlayerAttributes(SQLModel, table=True):
     player_id: int | None = Field(
-        default=None, foreign_key="player.id", primary_key=True
+        alias="PGID", default=None, foreign_key="player.id", primary_key=True
     )
     PTEN: int
     PPOE: int


### PR DESCRIPTION
The current method for creating a url endpoint for a single player is flawed, shown by the examples in #17. This pull request implements a solution by creating a `url_name` attribute created at data ingestion for the Player model. The `url_name` is created by combining the first and last name, removing non-alphabetical characters, and appending a count for the number of identical urls to handle players with identical names.

Resolves #17.