### PR TITLE
Add coverage information to README.md

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,9 @@ jobs:
                 coverage run -m pytest
                 coverage report --show-missing
                 coverage html --title "${@-coverage}"
+
+            - name: Store coverage report
+              uses: actions/upload-artifact@v4
+              with:
+                name: coverage-html
+                path: htmlcov

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 <p align="center">
   📊 Self-hosted sports statistics website using NCAA game saves.
 </p>
+<p align="center">
+<a href="https://github.com/hansmissenheim/cfb-reference/actions?query=workflow%3ATest" target="_blank"><img src="https://github.com/hansmissenheim/cfb-reference/workflows/Test/badge.svg" alt="Test"></a>
+</p>
 
 ![Preview](img/preview-homepage.png)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@
   📊 Self-hosted sports statistics website using NCAA game saves.
 </p>
 <p align="center">
-<a href="https://github.com/hansmissenheim/cfb-reference/actions?query=workflow%3ATest" target="_blank"><img src="https://github.com/hansmissenheim/cfb-reference/workflows/Test/badge.svg" alt="Test"></a>
+<a href="https://github.com/hansmissenheim/cfb-reference/actions?query=workflow%3ATest" target="_blank">
+    <img src="https://github.com/hansmissenheim/cfb-reference/workflows/Test/badge.svg" alt="Test">
+</a>
+<a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/hansmissenheim/cfb-reference" target="_blank">
+    <img src="https://coverage-badge.samuelcolvin.workers.dev/hansmissenheim/cfb-reference.svg" alt="Coverage">
+</a>
 </p>
 
 ![Preview](img/preview-homepage.png)


### PR DESCRIPTION
This PR adds badges to the `README.md` file to display the current status of the GitHub workflow to run tests with **pytest** and the test coverage percentage. These badges provide visitors with a quick view of the project's development progress and code quality. Additionally, the GitHub workflow for uploading the coverage report was modified to allow for the coverage badge to function properly.